### PR TITLE
Add requirements file and Binder link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A preprint is available at: https://arxiv.org/abs/1903.00095
 
 To use the proposed approach, start by taking a look at the Jupyter notebook deep_ivim_demo.ipynb, or by clicking the Binder button below:
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/mathieuboudreau/deep_ivim/master)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/mathieuboudreau/deep_ivim/master?filepath=deep_ivim_demo.ipynb)
 
 Further code will be uploaded following publication.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ by _Sebastiano Barbieri, Oliver J. Gurney-Champion, Remy Klaassen, Harriet C. Th
 
 A preprint is available at: https://arxiv.org/abs/1903.00095
 
-To use the proposed approach, start by taking a look at the Jupyter notebook deep_ivim_demo.ipynb
+To use the proposed approach, start by taking a look at the Jupyter notebook deep_ivim_demo.ipynb, or by clicking the Binder button below:
+
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/mathieuboudreau/deep_ivim/master)
 
 Further code will be uploaded following publication.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+numpy
+matplotlib
+torch
+tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
-matplotlib
-torch
-tqdm
+numpy==1.17.3
+matplotlib==3.1.1
+torch==1.3.0
+tqdm==4.36.1


### PR DESCRIPTION
Cool project!

While I was checking it out, I noticed that with a small tweak, it could be compatible with the [MyBinder.org](https://mybinder.org) service, which allows Jupyter Notebooks to run on a container on their servers for free (no signup or installation required).

All I did was add a requirements file specifying the Python packages that you depend on, and added the Binder button to your README file. I ran your script on this service without any issues (and without any local installations!)

If you do choose to merge this pull request, I'd recommend that you update the Binder link so that it points to your repository (i.e. change `mathieuboudreau` in the link to `sebbarb`) in the link I linked to below:

https://github.com/mathieuboudreau/deep_ivim/blame/f0806c0fc07878b25a779b446b5441d5022428a6/README.md#L13

You can view what your README will look like by looking at my fork, and test it out by clicking the button: https://github.com/mathieuboudreau/deep_ivim

Hope this helps!
